### PR TITLE
Get rid of partial arbitrary monad support

### DIFF
--- a/examples/simple/Main.hs
+++ b/examples/simple/Main.hs
@@ -31,7 +31,7 @@ data CounterCmd method return where
    IncreaseCounter ::CounterCmd Cmd Int
    AddToCounter ::Int -> CounterCmd Cmd Int
 
-handleCmd :: CounterCmd method a -> HandlerType method CounterModel CounterEvent IO a
+handleCmd :: CounterCmd method a -> HandlerType method CounterModel CounterEvent a
 handleCmd = \case
     GetCounter      -> Query $ pure
     IncreaseCounter -> Cmd $ \m -> pure (m + 1, [CounterIncreased])

--- a/test/DomainDriven/Persistance/PostgresIORefStateSpec.hs
+++ b/test/DomainDriven/Persistance/PostgresIORefStateSpec.hs
@@ -37,7 +37,7 @@ mkTestConn :: IO Connection
 mkTestConn = connect $ ConnectInfo { connectHost     = "localhost"
                                    , connectPort     = 5432
                                    , connectUser     = "postgres"
-                                   , connectPassword = "test"
+                                   , connectPassword = "postgres"
                                    , connectDatabase = "domaindriven"
                                    }
 

--- a/test/DomainDriven/ServerSpec.hs
+++ b/test/DomainDriven/ServerSpec.hs
@@ -42,7 +42,7 @@ type ExpectedReverseText
 expectedReverseText :: Text -> ClientM Text
 expectedReverseText = client (Proxy @ExpectedReverseText)
 
-handleTestAction :: ActionHandler () () TestAction IO
+handleTestAction :: ActionHandler () () TestAction
 handleTestAction = \case
     ReverseText t -> Cmd $ \() -> pure (T.reverse t, [])
 

--- a/test/StoreModel.hs
+++ b/test/StoreModel.hs
@@ -89,7 +89,7 @@ type StoreModel = M.Map ItemKey ItemInfo
 ------------------------------------------------------------------------------------------
 -- Action handlers                                                                      --
 ------------------------------------------------------------------------------------------
-handleStoreAction :: ActionHandler StoreModel StoreEvent StoreAction IO
+handleStoreAction :: ActionHandler StoreModel StoreEvent StoreAction
 handleStoreAction = \case
     BuyItem iKey quantity' -> Cmd $ \m -> do
         let available = maybe 0 quantity $ M.lookup iKey m
@@ -103,7 +103,7 @@ handleStoreAction = \case
     AdminAction cmd     -> handleAdminAction cmd
     ItemAction iKey cmd -> handleItemAction iKey cmd
 
-handleAdminAction :: ActionHandler StoreModel StoreEvent AdminAction IO
+handleAdminAction :: ActionHandler StoreModel StoreEvent AdminAction
 handleAdminAction = \case
     Restock iKey q -> Cmd $ \m -> do
         when (M.notMember iKey m) $ throwM err404
@@ -115,7 +115,7 @@ handleAdminAction = \case
         when (M.notMember iKey m) $ throwM err404
         pure ((), [RemovedItem iKey])
 
-handleItemAction :: ItemKey -> ActionHandler StoreModel StoreEvent ItemAction IO
+handleItemAction :: ItemKey -> ActionHandler StoreModel StoreEvent ItemAction
 handleItemAction iKey = \case
     StockQuantity -> Query $ \m -> do
         i <- getItem m


### PR DESCRIPTION
I took a stab at implementing it properly but failed to get the
abstraction I wanted.

I was hoping to be able to have constraints passed up so from individual
ActionHandlers.

In the end I concluded that this feature isn't worth all that much. I
was never going to allow something that doesn't implement MonadUnliftIO,
so pretty much just ReaderT r IO. But it's not very invoncenient to just
pass that `r` as an explicit parameter to the handler anyway.

This would also add an extra type parameter and the template haskell
part need to be aware of it.

I'm glad to get rid of it.